### PR TITLE
Add 47.952 fps (48000/1001) timecode support across Python, JS, and Go

### DIFF
--- a/go/timecode/rate.go
+++ b/go/timecode/rate.go
@@ -14,6 +14,7 @@ const (
 var (
 	Rate_None   = Rate{"", 0, 0, 0, 0}
 	Rate_23_976 = Rate{"23.976", 24, 0, 24000, 1001}
+	Rate_47_952 = Rate{"47.952", 48, 0, 48000, 1001}
 	Rate_24     = Rate{"24", 24, 0, 24, 1}
 	Rate_25     = Rate{"25", 25, 0, 25, 1}
 	Rate_30     = Rate{"30", 30, 0, 30, 1}
@@ -40,6 +41,8 @@ func ParseRate(str string) (Rate, bool) {
 	switch str {
 	case "23.976", "23.98":
 		return Rate_23_976, true
+	case "47.952", "47.95":
+		return Rate_47_952, true
 	case "24", "24.0":
 		return Rate_24, true
 	case "25", "25.0":
@@ -64,6 +67,8 @@ func RateFromFraction(num, den int) Rate {
 	switch (fraction{num, den}) {
 	case fraction{24000, 1001}:
 		return Rate_23_976
+	case fraction{48000, 1001}:
+		return Rate_47_952
 	case fraction{24, 1}:
 		return Rate_24
 	case fraction{25, 1}:

--- a/go/timecode/rate_test.go
+++ b/go/timecode/rate_test.go
@@ -14,6 +14,7 @@ func TestRateFromFraction(t *testing.T) {
 	}
 	cases := []testCase{
 		{24000, 1001, timecode.Rate_23_976},
+		{48000, 1001, timecode.Rate_47_952},
 		{24, 1, timecode.Rate_24},
 		{30, 1, timecode.Rate_30},
 		{30000, 1001, timecode.Rate_29_97},
@@ -29,6 +30,7 @@ func TestRateFromFraction(t *testing.T) {
 func TestRateFromFractionBuiltinRates(t *testing.T) {
 	cases := []timecode.Rate{
 		timecode.Rate_23_976,
+		timecode.Rate_47_952,
 		timecode.Rate_24,
 		timecode.Rate_30,
 		timecode.Rate_29_97,

--- a/go/timecode/timecode.go
+++ b/go/timecode/timecode.go
@@ -39,6 +39,8 @@ func (t *Timecode) Seconds() float64 {
 		return truncate(float64(t.frame*int64(t.rate.Den))/float64(t.rate.Num), 5)
 	case "23.976":
 		return truncate(float64(t.frame*int64(t.rate.Den))/float64(t.rate.Num), 5)
+	case "47.952":
+		return truncate(float64(t.frame*int64(t.rate.Den))/float64(t.rate.Num), 5)
 	case "59.94":
 		return truncate(float64(t.frame*int64(t.rate.Den))/float64(t.rate.Num), 5)
 	default:

--- a/go/timecode/timecode_test.go
+++ b/go/timecode/timecode_test.go
@@ -222,6 +222,7 @@ func TestNDFToTc(t *testing.T) {
 		"test_14": {TimecodeStr: "01:47:18:23", FrameRate: timecode.Rate_23_976, ExpectedTc: 6445.397291666667}, //6445.397291666667 = (3600*24+47*60*24+18*24+23)*1001/24000
 		"test_15": {TimecodeStr: "01:47:18:23", FrameRate: timecode.Rate_24, ExpectedTc: 6438.958333333333},     //6438.958333333333 = (3600*24+47*60*24+18*24+23)/24
 		"test_16": {TimecodeStr: "01:17:41:52", FrameRate: timecode.Rate_59_94, ExpectedTc: 4666.528533333333},  //4666.528533333333 = (3600*60+17*60*60+41*60+52)*1001/60000
+		"test_17": {TimecodeStr: "01:47:18:23", FrameRate: timecode.Rate_47_952, ExpectedTc: 6444.917645833333}, //6444.917645833333 = (3600*48+47*60*48+18*48+23)*1001/48000
 	}
 
 	for name, test := range tests {
@@ -252,6 +253,7 @@ func TestTcConversion(t *testing.T) {
 		"test_59_94":   {FrameRate: timecode.Rate_59_94, Sep: ";", TcFormat: timecode.SmpteTimecodeDrop},
 		"test_30":      {FrameRate: timecode.Rate_30, Sep: ":", TcFormat: timecode.SmpteTimecodeNonDrop},
 		"test_23_976":  {FrameRate: timecode.Rate_23_976, Sep: ":", TcFormat: timecode.SmpteTimecodeNonDrop},
+		"test_47_952":  {FrameRate: timecode.Rate_47_952, Sep: ":", TcFormat: timecode.SmpteTimecodeNonDrop},
 		"test_29_97_2": {FrameRate: timecode.Rate_29_97, Sep: ".", TcFormat: timecode.NormalTimestamp},
 	}
 

--- a/js/src/rate.ts
+++ b/js/src/rate.ts
@@ -15,6 +15,9 @@ export function parseRate(str: string): Rate | null {
 		case '23.976':
 		case '23.98':
 			return Rate_23_976;
+		case '47.952':
+		case '47.95':
+			return Rate_47_952;
 		case '24':
 			return Rate_24;
 		case '24.0':
@@ -43,6 +46,8 @@ export function parseRate(str: string): Rate | null {
 export function rateFromFraction(num: number, den: number): Rate {
 	if (num === 24000 && den === 1001) {
 		return Rate_23_976;
+	} else if (num === 48000 && den === 1001) {
+		return Rate_47_952;
 	} else if (num === 24 && den === 1) {
 		return Rate_24;
 	} else if (num === 30000 && den === 1001) {
@@ -140,6 +145,13 @@ export const Rate_23_976: Rate = {
 	num: 24000,
 	den: 1001,
 	rateStr: "23.976"
+};
+export const Rate_47_952: Rate = {
+	nominal: 48,
+	drop: 0,
+	num: 48000,
+	den: 1001,
+	rateStr: "47.952"
 };
 
 export function getPlaybackDurationMilliseconds(rate: Rate): number {

--- a/js/src/tests/testTcUtils.test.ts
+++ b/js/src/tests/testTcUtils.test.ts
@@ -37,6 +37,7 @@ describe('Non-Drop Frame Timecode Tests', () => {
         ["01:39:23:23", tcUtils.Rate_30, 5963.7666],
         ["01:47:18:23", tcUtils.Rate_23_976, 6445.397291666667],
         ["01:47:18:23", tcUtils.Rate_24, 6438.958333333333],
+        ["01:47:18:23", tcUtils.Rate_47_952, 6444.917645833333],
         ["01:17:41:52", tcUtils.Rate_59_94, 4666.528533333333],
     ];
 
@@ -64,6 +65,7 @@ describe('testing timecode', () => {
     { framerate: tcUtils.Rate_29_97, sep: ';', timestampFormat: tcUtils.smpteTimecodeDrop },
     { framerate: tcUtils.Rate_59_94, sep: ';', timestampFormat: tcUtils.smpteTimecodeDrop },
     { framerate: tcUtils.Rate_23_976, sep: ':', timestampFormat: tcUtils.smpteTimecodeNonDrop },
+    { framerate: tcUtils.Rate_47_952, sep: ':', timestampFormat: tcUtils.smpteTimecodeNonDrop },
     { framerate: tcUtils.Rate_30, sep: ':', timestampFormat: tcUtils.smpteTimecodeNonDrop },
     { framerate: tcUtils.Rate_29_97, sep: '.', timestampFormat: tcUtils.normalTimestamp}
   ];

--- a/js/src/timecode.ts
+++ b/js/src/timecode.ts
@@ -23,7 +23,7 @@ export class Timecode {
 	
 	public seconds(): number {
 		const rateStr = this.rate.rateStr;
-		if (rateStr === "29.97" || rateStr === "59.94" || rateStr === "23.976") {
+		if (rateStr === "29.97" || rateStr === "59.94" || rateStr === "23.976" || rateStr === "47.952") {
 		  return truncate(parseFloat((this.frame * this.rate.den / this.rate.num).toFixed(3)), 5);
 		} else {
 		  return truncate(parseFloat((this.frame / this.rate.nominal).toFixed(3)), 5);

--- a/py/tc_utils/__init__.py
+++ b/py/tc_utils/__init__.py
@@ -15,6 +15,7 @@ Rate_50 = Rate.generate_rate(50)
 Rate_59_94 = Rate.generate_rate("59.94")
 Rate_60 = Rate.generate_rate(60)
 Rate_23_976 = Rate.generate_rate("23.976")
+Rate_47_952 = Rate.generate_rate("47.952")
 
 def GetTimecodeType(time_str: str) -> str:
     if normaTimeRegex.match(time_str):

--- a/py/tc_utils/timecode.py
+++ b/py/tc_utils/timecode.py
@@ -12,6 +12,8 @@ class Rate:
     def generate_rate(rate_str):
         if rate_str == "23.976":
             return Rate("23.976", 24, 0, 24000, 1001)
+        elif rate_str == "47.952":
+            return Rate("47.952", 48, 0, 48000, 1001)
         elif rate_str == "59.94":
             return Rate("59.94", 60, 4, 60000, 1001)
         elif rate_str == "29.97":
@@ -46,6 +48,8 @@ class Timecode:
         elif self.rate.rate_str == "59.94":
             return truncate(float(self.frame) * self.rate.den / self.rate.num, 5)
         elif self.rate.rate_str == "23.976":
+            return truncate(float(self.frame) * self.rate.den / self.rate.num, 5)
+        elif self.rate.rate_str == "47.952":
             return truncate(float(self.frame) * self.rate.den / self.rate.num, 5)
         else:
             return truncate(float(self.frame) / float(self.rate.nominal), 5)

--- a/py/tests/test_tc_utils.py
+++ b/py/tests/test_tc_utils.py
@@ -34,6 +34,7 @@ def test_tc_type(input, expected):
     ("01:39:23:23", tc_utils.Rate_30, 5963.7666), # 5963.7666 = ((3600*30)+(39*60*30)+(23*30)+23)/30
     ("01:47:18:23", tc_utils.Rate_23_976, 6445.397291666667),  # 6445.397291666667 = (3600*24+47*60*24+18*24+23)*1001/24000
     ("01:47:18:23", tc_utils.Rate_24, 6438.958333333333),  # 6438.958333333333 = (3600*24+47*60*24+18*24+23)/24
+    ("01:47:18:23", tc_utils.Rate_47_952, 6444.917645833333),  # 6444.917645833333 = (3600*48+47*60*48+18*48+23)*1001/48000
     ("01:17:41:52", tc_utils.Rate_59_94, 4666.528533333333), # 4666.528533333333 = (3600*60+17*60*60+41*60+52)*1001/60000
     ])
 def test_ndf_tc(input, rate, expected):
@@ -50,6 +51,7 @@ def test_ndf_tc(input, rate, expected):
     (tc_utils.Rate_29_97, ';',tc_utils.SmpteTimecodeDrop),
     (tc_utils.Rate_59_94, ';',tc_utils.SmpteTimecodeDrop),
     (tc_utils.Rate_23_976, ':',tc_utils.SmpteTimecodeNonDrop),
+    (tc_utils.Rate_47_952, ':',tc_utils.SmpteTimecodeNonDrop),
     (tc_utils.Rate_30, ':',tc_utils.SmpteTimecodeNonDrop),
     (tc_utils.Rate_29_97, '.',tc_utils.NormalTimestamp),
 ])


### PR DESCRIPTION
Added 47.952 fps (48000/1001) SMPTE timecode support in Python, JS, and Go (non-drop, same pattern as 23.976), plus tests.