### PR TITLE
Add 50 fps support in Go and JS

### DIFF
--- a/go/timecode/rate.go
+++ b/go/timecode/rate.go
@@ -19,6 +19,7 @@ var (
 	Rate_25     = Rate{"25", 25, 0, 25, 1}
 	Rate_30     = Rate{"30", 30, 0, 30, 1}
 	Rate_29_97  = Rate{"29.97", 30, 2, 30000, 1001}
+	Rate_50     = Rate{"50", 50, 0, 50, 1}
 	Rate_60     = Rate{"60", 60, 0, 60, 1}
 	Rate_59_94  = Rate{"59.94", 60, 4, 60000, 1001}
 )
@@ -39,7 +40,7 @@ func (r *Rate) String() string {
 // ParseRate returns a Rate from a string representation.
 func ParseRate(str string) (Rate, bool) {
 	switch str {
-	case "23.976", "23.98":
+	case "23.976", "23.98", "23.97":
 		return Rate_23_976, true
 	case "47.952", "47.95":
 		return Rate_47_952, true
@@ -51,6 +52,8 @@ func ParseRate(str string) (Rate, bool) {
 		return Rate_30, true
 	case "29.97":
 		return Rate_29_97, true
+	case "50", "50.0":
+		return Rate_50, true
 	case "60", "60.0":
 		return Rate_60, true
 	case "59.94":
@@ -77,6 +80,8 @@ func RateFromFraction(num, den int) Rate {
 		return Rate_30
 	case fraction{30000, 1001}:
 		return Rate_29_97
+	case fraction{50, 1}:
+		return Rate_50
 	case fraction{60, 1}:
 		return Rate_60
 	case fraction{60000, 1001}:

--- a/go/timecode/rate_test.go
+++ b/go/timecode/rate_test.go
@@ -16,8 +16,10 @@ func TestRateFromFraction(t *testing.T) {
 		{24000, 1001, timecode.Rate_23_976},
 		{48000, 1001, timecode.Rate_47_952},
 		{24, 1, timecode.Rate_24},
+		{25, 1, timecode.Rate_25},
 		{30, 1, timecode.Rate_30},
 		{30000, 1001, timecode.Rate_29_97},
+		{50, 1, timecode.Rate_50},
 		{60, 1, timecode.Rate_60},
 		{60000, 1001, timecode.Rate_59_94},
 	}
@@ -32,13 +34,43 @@ func TestRateFromFractionBuiltinRates(t *testing.T) {
 		timecode.Rate_23_976,
 		timecode.Rate_47_952,
 		timecode.Rate_24,
+		timecode.Rate_25,
 		timecode.Rate_30,
 		timecode.Rate_29_97,
+		timecode.Rate_50,
 		timecode.Rate_60,
 		timecode.Rate_59_94,
 	}
 	for _, rate := range cases {
 		newRate := timecode.RateFromFraction(rate.Num, rate.Den)
 		require.Equal(t, rate, newRate)
+	}
+}
+
+func TestParseRate(t *testing.T) {
+	type testCase struct {
+		str  string
+		rate timecode.Rate
+	}
+	cases := []testCase{
+		{"23.976", timecode.Rate_23_976},
+		{"23.98", timecode.Rate_23_976},
+		{"23.97", timecode.Rate_23_976},
+		{"47.952", timecode.Rate_47_952},
+		{"47.95", timecode.Rate_47_952},
+		{"24", timecode.Rate_24},
+		{"25", timecode.Rate_25},
+		{"25.0", timecode.Rate_25},
+		{"29.97", timecode.Rate_29_97},
+		{"30", timecode.Rate_30},
+		{"50", timecode.Rate_50},
+		{"50.0", timecode.Rate_50},
+		{"59.94", timecode.Rate_59_94},
+		{"60", timecode.Rate_60},
+	}
+	for _, tc := range cases {
+		rate, ok := timecode.ParseRate(tc.str)
+		require.True(t, ok, "ParseRate(%q)", tc.str)
+		require.Equal(t, tc.rate, rate)
 	}
 }

--- a/js/src/rate.ts
+++ b/js/src/rate.ts
@@ -14,6 +14,7 @@ export function parseRate(str: string): Rate | null {
 	switch (str) {
 		case '23.976':
 		case '23.98':
+		case '23.97':
 			return Rate_23_976;
 		case '47.952':
 		case '47.95':
@@ -35,9 +36,11 @@ export function parseRate(str: string): Rate | null {
 		case '60.0':
 			return Rate_60;
 		case '25':
-			return Rate_25;
 		case '25.0':
-				return Rate_25;
+			return Rate_25;
+		case '50':
+		case '50.0':
+			return Rate_50;
 		default:
 			return null;
 	}
@@ -50,10 +53,14 @@ export function rateFromFraction(num: number, den: number): Rate {
 		return Rate_47_952;
 	} else if (num === 24 && den === 1) {
 		return Rate_24;
+	} else if (num === 25 && den === 1) {
+		return Rate_25;
 	} else if (num === 30000 && den === 1001) {
 		return Rate_29_97;
 	} else if (num === 30 && den === 1) {
 		return Rate_30;
+	} else if (num === 50 && den === 1) {
+		return Rate_50;
 	} else if (num === 60000 && den === 1001) {
 		return Rate_59_94;
 	} else if (num === 60 && den === 1) {

--- a/js/src/tests/rate.test.ts
+++ b/js/src/tests/rate.test.ts
@@ -1,10 +1,14 @@
 import {
 	Rate,
+	parseRate,
 	rateFromFraction,
 	Rate_23_976,
 	Rate_24,
+	Rate_25,
 	Rate_29_97,
 	Rate_30,
+	Rate_47_952,
+	Rate_50,
 	Rate_59_94,
 	Rate_60,
 } from '../rate';
@@ -13,9 +17,12 @@ describe('testing create framerate from fraction', () => {
 	test('frame rate from fraction', () => {
 		const cases: [number, number, Rate][] = [
 			[24000, 1001, Rate_23_976],
+			[48000, 1001, Rate_47_952],
 			[24, 1, Rate_24],
+			[25, 1, Rate_25],
 			[30, 1, Rate_30],
 			[30000, 1001, Rate_29_97],
+			[50, 1, Rate_50],
 			[60, 1, Rate_60],
 			[60000, 1001, Rate_59_94],
 		];
@@ -30,9 +37,12 @@ describe('testing create framerate from fraction', () => {
 	test('frame rate from fraction for built-in rates', () => {
 		const cases: Rate[] = [
 			Rate_23_976,
+			Rate_47_952,
 			Rate_24,
+			Rate_25,
 			Rate_30,
 			Rate_29_97,
+			Rate_50,
 			Rate_60,
 			Rate_59_94,
 		];
@@ -42,6 +52,27 @@ describe('testing create framerate from fraction', () => {
 			expect(newRate.den).toBe(rate.den);
 			expect(newRate.nominal).toBe(rate.nominal);
 			expect(newRate.drop).toBe(rate.drop);
+		}
+	});
+	test('parse rate strings', () => {
+		const cases: [string, Rate][] = [
+			['23.976', Rate_23_976],
+			['23.98', Rate_23_976],
+			['23.97', Rate_23_976],
+			['47.952', Rate_47_952],
+			['47.95', Rate_47_952],
+			['24', Rate_24],
+			['25', Rate_25],
+			['25.0', Rate_25],
+			['29.97', Rate_29_97],
+			['30', Rate_30],
+			['50', Rate_50],
+			['50.0', Rate_50],
+			['59.94', Rate_59_94],
+			['60', Rate_60],
+		];
+		for (const [str, expected] of cases) {
+			expect(parseRate(str)).toBe(expected);
 		}
 	});
 });


### PR DESCRIPTION
- Add Rate_50 to Go (ParseRate + RateFromFraction)
- Wire Rate_50 through JS parseRate and rateFromFraction
- Map Rate_25 fraction (25/1) in JS rateFromFraction
- Accept "23.97" as an alias for 23.976
- Expand Go/JS rate tests for 25, 50, and 47.952